### PR TITLE
Fix errors with enter and unary operators on Linux

### DIFF
--- a/PySilon.sh
+++ b/PySilon.sh
@@ -32,13 +32,15 @@ if [ $mode = 'c' ]; then
             sudo dnf update -y && sudo dnf install wine -y
         elif [ $package_manager = 'p' ]; then
             sudo pacman -Sy wine --noconfirm
+        elif [ -z $package_manager ]; then
+            echo -e "\e[34m[-] Enter was pressed, skipping.\e[0m"
         else
-            echo -e "\e[31m[x] Enter was pressed or invalid input was given, skipping.\e[0m"
+            echo -e "\e[31m[x] Invalid input was given, skipping.\e[0m"
         fi
     elif [ $wine_installed = 'y' ]; then
         :
     else
-        echo -e "\e[31m[x] Enter was pressed or invalid input was given, skipping.\e[0m"
+        echo -e "\e[31m[x] Enter was pressed or other invalid input was given, skipping.\e[0m"
     fi
 
     # Ask to download and install Python in Wine
@@ -52,8 +54,10 @@ if [ $mode = 'c' ]; then
         echo -e "\e[36m[#] Launching Python installer through Wine...\e[0m"
         echo -e "\e[1;35m[i] Make sure to add Python to PATH and go to \"Customize Installation > Next > Install for all users\" in the installer!\e[0m"
         wine ./python-3.10.8-amd64.exe # Change version to the version set in the above link
+    elif [ -z $install_python ]; then
+        echo -e "\e[34m[-] Enter was pressed, skipping.\e[0m"
     else
-        echo -e "\e[31m[x] Enter was pressed or invalid input was given, skipping.\e[0m"
+        echo -e "\e[31m[x] Invalid input was given, skipping.\e[0m"
     fi
 
     # Ask to create a new venv (or keep the existing, in case it already exists)
@@ -62,11 +66,15 @@ if [ $mode = 'c' ]; then
     if [ $create_venv = 'y' ]; then
         wine python -m pip install wheel setuptools
         wine python -m venv pysilon
+    elif [ -z $create_venv ]; then
+        echo -e "\e[34m[-] Enter was pressed, skipping.\e[0m"
+    else
+        echo -e "\e[31m[x] Invalid input was given, skipping.\e[0m"
     fi
 
     # Initializing venv
     echo -e "\e[36m[#] Initializing the virtual environment...\e[0m"
-    wine call "pysilon\\Scripts\\activate.bat"
+    wine call ".\\pysilon\\Scripts\\activate.bat" ###* Attention needed / Might not work (activate.bat does not get called) ###
 
     # Install requirements.txt
     echo -e "\e[36m[#] Installing PIP requirements.txt...\e[0m"
@@ -78,7 +86,7 @@ elif [ $mode = 'r' ]; then
     :
 # If no mode was selected, display error and continue
 else
-    echo -e "\e[31mInvalid input, proceeding to the execuion of builder.py anyways.\e[0m"
+    echo -e "\e[31m[x] Invalid input, proceeding to the execuion of builder.py anyways.\e[0m"
 fi
 
 # Running builder.py

--- a/PySilon.sh
+++ b/PySilon.sh
@@ -7,7 +7,7 @@
 # Supported distros: Ubuntu, Fedora, Arch (and derivatives)
 # Not supported: openSUSE, Nix, Void, Debian, Alpine, etc.
 
-if [ $(whoami) = 'root' ]; then
+if [ $(whoami) == 'root' ]; then
     echo -e "\e[1;31mYou must not run this as root. Rerun without root.\e[0m"
     exit
 fi
@@ -16,28 +16,28 @@ echo -e "[+] Configure Wine first? \e[32m[c]onfigure\e[0m/\e[31m[r]un anyways\e[
 read -p "$ " mode
 
 # If configuration mode was selected, do these:
-if [ $mode = 'c' ]; then
+if [ "$mode" == 'c' ]; then
     # Ask if wine is installed
     echo -e "[+] Do you have wine already installed? \e[32m[y]es\e[0m/\e[31m[n]o\e[0m (defaults to yes)"
     read -p "$ " wine_installed
     # If wine is not installed, show prompt to choose package manager
-    if [ $wine_installed = 'n' ]; then
+    if [ "$wine_installed" == 'n' ]; then
         echo -e "[+] Select your package manager (\e[34m[a]pt\e[0m, \e[34m[d]nf\e[0m, \e[34m[p]acman\e[0m) or hit \e[34menter\e[0m to skip."
         read -p "$ " package_manager
 
         # Install wine using the selected package manager
-        if [ $package_manager = 'a' ]; then
+        if [ "$package_manager" == 'a' ]; then
             sudo apt update -y && sudo apt install wine -y
-        elif [ $package_manager = 'd' ]; then
+        elif [ "$package_manager" == 'd' ]; then
             sudo dnf update -y && sudo dnf install wine -y
-        elif [ $package_manager = 'p' ]; then
+        elif [ "$package_manager" == 'p' ]; then
             sudo pacman -Sy wine --noconfirm
-        elif [ -z $package_manager ]; then
+        elif [ -z "$package_manager" ]; then
             echo -e "\e[34m[-] Enter was pressed, skipping.\e[0m"
         else
             echo -e "\e[31m[x] Invalid input was given, skipping.\e[0m"
         fi
-    elif [ $wine_installed = 'y' ]; then
+    elif [ "$wine_installed" == 'y' ]; then
         :
     else
         echo -e "\e[31m[x] Enter was pressed or other invalid input was given, skipping.\e[0m"
@@ -48,13 +48,13 @@ if [ $mode = 'c' ]; then
     read -p "$ " install_python
 
     # If user entered 'y', download and install Python in Wine
-    if [ $install_python = 'y' ]; then
+    if [ "$install_python" == 'y' ]; then
         echo -e "\e[36m[#] Fetching Python for Windows...\e[0m"
-        wget https://www.python.org/ftp/python/3.10.8/python-3.10.8-amd64.exe # Change link for a different version (3.10.8 works fine under wine)
+        wget https://www.python.org/ftp/python/3.10.8/python-3.10.8-amd64.exe -O python-3.x.x-amd64.exe # Change link for a different version (3.10.8 works fine under wine)
         echo -e "\e[36m[#] Launching Python installer through Wine...\e[0m"
         echo -e "\e[1;35m[i] Make sure to add Python to PATH and go to \"Customize Installation > Next > Install for all users\" in the installer!\e[0m"
-        wine ./python-3.10.8-amd64.exe # Change version to the version set in the above link
-    elif [ -z $install_python ]; then
+        wine ./python-3.x.x-amd64.exe # Change version to the version set in the above link
+    elif [ -z "$install_python" ]; then
         echo -e "\e[34m[-] Enter was pressed, skipping.\e[0m"
     else
         echo -e "\e[31m[x] Invalid input was given, skipping.\e[0m"
@@ -63,10 +63,10 @@ if [ $mode = 'c' ]; then
     # Ask to create a new venv (or keep the existing, in case it already exists)
     echo -e "[+] Create new virtual environment? \e[32m[y]es\e[0m/\e[34menter\e[0m to skip (say yes if it's the first time running this)."
     read -p "$ " create_venv
-    if [ $create_venv = 'y' ]; then
+    if [ "$create_venv" == 'y' ]; then
         wine python -m pip install wheel setuptools
         wine python -m venv pysilon
-    elif [ -z $create_venv ]; then
+    elif [ -z "$create_venv" ]; then
         echo -e "\e[34m[-] Enter was pressed, skipping.\e[0m"
     else
         echo -e "\e[31m[x] Invalid input was given, skipping.\e[0m"
@@ -82,7 +82,7 @@ if [ $mode = 'c' ]; then
     wine python -m pip install -r requirements.txt
 
 # If run mode was selected, continue
-elif [ $mode = 'r' ]; then
+elif [ "$mode" == 'r' ]; then
     :
 # If no mode was selected, display error and continue
 else

--- a/PySilon.sh
+++ b/PySilon.sh
@@ -50,15 +50,27 @@ if [ $mode = 'c' ]; then
         echo -e "\e[36m[#] Fetching Python for Windows...\e[0m"
         wget https://www.python.org/ftp/python/3.10.8/python-3.10.8-amd64.exe # Change link for a different version (3.10.8 works fine under wine)
         echo -e "\e[36m[#] Launching Python installer through Wine...\e[0m"
-        echo -e "\e[1;35m[i] Make sure to add Python to PATH in the installer!\e[0m"
+        echo -e "\e[1;35m[i] Make sure to add Python to PATH and go to \"Customize Installation > Next > Install for all users\" in the installer!\e[0m"
         wine ./python-3.10.8-amd64.exe # Change version to the version set in the above link
     else
         echo -e "\e[31m[x] Enter was pressed or invalid input was given, skipping.\e[0m"
     fi
 
+    # Ask to create a new venv (or keep the existing, in case it already exists)
+    echo -e "[+] Create new virtual environment? \e[32m[y]es\e[0m/\e[34menter\e[0m to skip (say yes if it's the first time running this)."
+    read -p "$ " create_venv
+    if [ $create_venv = 'y' ]; then
+        wine python -m pip install wheel setuptools
+        wine python -m venv pysilon
+    fi
+
+    # Initializing venv
+    echo -e "\e[36m[#] Initializing the virtual environment...\e[0m"
+    wine call "pysilon\\Scripts\\activate.bat"
+
     # Install requirements.txt
     echo -e "\e[36m[#] Installing PIP requirements.txt...\e[0m"
-    wine pip install wheel setuptools
+    wine python -m pip install wheel setuptools
     wine python -m pip install -r requirements.txt
 
 # If run mode was selected, continue

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Advanced RAT malware written in Python, fully controllable through Discord with 
 
 Join our discord to keep up with the progress, ask questions, recommend features and talk to like minded people!
 
-[![Discord](https://img.shields.io/discord/1114568569850699847?color=7289da&logo=discord&logoColor=white)](https://discord.gg/J7pYVqcntm)
+[![Discord](https://img.shields.io/discord/1114568569850699847?color=7289da&logo=discord&logoColor=white)](https://discord.gg/pysilon)
 
 ## Showcase
 


### PR DESCRIPTION
- Read if input was empty (thanks @whois-hoeless)
- Fix `[: =: unary operator expected` error