### PR TITLE
Builder compatibility for Alpine (tested)

### DIFF
--- a/PySilon.sh
+++ b/PySilon.sh
@@ -4,8 +4,14 @@
 # Author: Neek8044
 # Description: Bash script to compile PySilon under Linux with wine
 
-# Supported distros: Ubuntu, Fedora, Arch (and derivatives)
-# Not supported: openSUSE, Nix, Void, Debian, Alpine, etc.
+# Supported distros: Ubuntu, Fedora, Arch, Alpine, (and their derivatives)
+# Not supported: openSUSE, Nix, Void, Debian, etc.
+
+#TODO: 
+# When running on Alpine, 'wine64' needs to be called instead of 'wine'. 
+# Because of overuse of 'if' statements, the wine command should be made a variable and change it 
+# at the start and use it dynamically instead of having to constantly check if the package manager is 'apk' 
+# to find if the script is running on Alpine or not and execute the right command (wine or wine64).
 
 if [ $(whoami) == 'root' ]; then
     echo -e "\e[1;31mYou must not run this as root. Rerun without root.\e[0m"
@@ -22,16 +28,18 @@ if [ "$mode" == 'c' ]; then
     read -p "$ " wine_installed
     # If wine is not installed, show prompt to choose package manager
     if [ "$wine_installed" == 'n' ]; then
-        echo -e "[+] Select your package manager (\e[34m[a]pt\e[0m, \e[34m[d]nf\e[0m, \e[34m[p]acman\e[0m) or hit \e[34menter\e[0m to skip."
+        echo -e "[+] Select your package manager (\e[34m[1] apt\e[0m, \e[34m[2] dnf\e[0m, \e[34m[3] pacman\e[0m, \e[34m[4] apk\e[0m) or hit \e[34menter\e[0m to skip."
         read -p "$ " package_manager
 
         # Install wine using the selected package manager
-        if [ "$package_manager" == 'a' ]; then
+        if [ "$package_manager" == '1' ]; then
             sudo apt update -y && sudo apt install wine -y
-        elif [ "$package_manager" == 'd' ]; then
+        elif [ "$package_manager" == '2' ]; then
             sudo dnf update -y && sudo dnf install wine -y
-        elif [ "$package_manager" == 'p' ]; then
+        elif [ "$package_manager" == '3' ]; then
             sudo pacman -Sy wine --noconfirm
+        elif [ "$package_manager" == '4' ]; then
+            sudo apk update && sudo apk add wine
         elif [ -z "$package_manager" ]; then
             echo -e "\e[34m[-] Enter was pressed, skipping.\e[0m"
         else
@@ -53,7 +61,12 @@ if [ "$mode" == 'c' ]; then
         wget https://www.python.org/ftp/python/3.10.8/python-3.10.8-amd64.exe -O python-3.x.x-amd64.exe # Change link for a different version (3.10.8 works fine under wine)
         echo -e "\e[36m[#] Launching Python installer through Wine...\e[0m"
         echo -e "\e[1;35m[i] Make sure to add Python to PATH and go to \"Customize Installation > Next > Install for all users\" in the installer!\e[0m"
-        wine ./python-3.x.x-amd64.exe # Change version to the version set in the above link
+        # Run the Python installer
+        if [ "$package_manager" == '4' ]; then
+            wine64 ./python-3.x.x-amd64.exe
+        else
+            wine ./python-3.x.x-amd64.exe
+        fi
     elif [ -z "$install_python" ]; then
         echo -e "\e[34m[-] Enter was pressed, skipping.\e[0m"
     else
@@ -64,8 +77,13 @@ if [ "$mode" == 'c' ]; then
     echo -e "[+] Create new virtual environment? \e[32m[y]es\e[0m/\e[34menter\e[0m to skip (say yes if it's the first time running this)."
     read -p "$ " create_venv
     if [ "$create_venv" == 'y' ]; then
-        wine python -m pip install wheel setuptools
-        wine python -m venv pysilon
+        if [ "$package_manager" == '4' ]; then
+            wine64 python -m pip install wheel setuptools
+            wine64 python -m venv pysilon
+        else
+            wine python -m pip install wheel setuptools
+            wine python -m venv pysilon
+        fi
     elif [ -z "$create_venv" ]; then
         echo -e "\e[34m[-] Enter was pressed, skipping.\e[0m"
     else
@@ -74,12 +92,22 @@ if [ "$mode" == 'c' ]; then
 
     # Initializing venv
     echo -e "\e[36m[#] Initializing the virtual environment...\e[0m"
-    wine call ".\\pysilon\\Scripts\\activate.bat" ###* Attention needed / Might not work (activate.bat does not get called) ###
+    ###* Attention needed / Might not work (activate.bat does not get called) ###
+    if [ "$package_manager" == '4' ]; then
+        wine64 call ".\\pysilon\\Scripts\\activate.bat"
+    elif
+        wine call ".\\pysilon\\Scripts\\activate.bat"
+    fi
 
     # Install requirements.txt
     echo -e "\e[36m[#] Installing PIP requirements.txt...\e[0m"
-    wine python -m pip install wheel setuptools
-    wine python -m pip install -r requirements.txt
+    if [ "$package_manager" == '4' ]; then
+        wine64 python -m pip install wheel setuptools
+        wine64 python -m pip install -r requirements.txt
+    else
+        wine python -m pip install wheel setuptools
+        wine python -m pip install -r requirements.txt
+    fi
 
 # If run mode was selected, continue
 elif [ "$mode" == 'r' ]; then
@@ -91,13 +119,17 @@ fi
 
 # Running builder.py
 echo -e "\e[36m[#] Running builder.py...\e[0m"
-wine python builder.py
+if [ "$package_manager" == '4' ]; then
+    wine64 python builder.py
+else
+    wine python builder.py
+fi
 
 echo
 echo -e "\e[33m#===============================================#\e[0m"
 echo -e "\e[33m# Software terminated.                          #\e[0m"
 echo -e "\e[33m#                                               #\e[0m"
-echo -e "\e[33m# Give me a star on Github!                     #\e[0m"
+echo -e "\e[33m# Give me a star and submit issues on Github!   #\e[0m"
 echo -e "\e[33m# https://github.com/mategol/PySilon-malware    #\e[0m"
 echo -e "\e[33m#===============================================#\e[0m"
 echo

--- a/PySilon.sh
+++ b/PySilon.sh
@@ -39,7 +39,7 @@ if [ "$mode" == 'c' ]; then
         elif [ "$package_manager" == '3' ]; then
             sudo pacman -Sy wine --noconfirm
         elif [ "$package_manager" == '4' ]; then
-            sudo apk update && sudo apk add wine
+            doas apk update && doas apk add wine
         elif [ -z "$package_manager" ]; then
             echo -e "\e[34m[-] Enter was pressed, skipping.\e[0m"
         else

--- a/PySilon.sh
+++ b/PySilon.sh
@@ -39,6 +39,7 @@ if [ "$mode" == 'c' ]; then
         elif [ "$package_manager" == '3' ]; then
             sudo pacman -Sy wine --noconfirm
         elif [ "$package_manager" == '4' ]; then
+            echo -e "\e[1mNOTE: In case wine did not install, check '/etc/apk/repositories' and make sure to have community repos enabled, and restart the script.\e[0m"
             doas apk update && doas apk add wine
         elif [ -z "$package_manager" ]; then
             echo -e "\e[34m[-] Enter was pressed, skipping.\e[0m"
@@ -95,7 +96,7 @@ if [ "$mode" == 'c' ]; then
     ###* Attention needed / Might not work (activate.bat does not get called) ###
     if [ "$package_manager" == '4' ]; then
         wine64 call ".\\pysilon\\Scripts\\activate.bat"
-    elif
+    else
         wine call ".\\pysilon\\Scripts\\activate.bat"
     fi
 

--- a/builder.py
+++ b/builder.py
@@ -256,7 +256,7 @@ if len(sys.argv) > 1:
         cli = 'soon' # CLI mode will be added soon...
 else:
     root = Tk()
-    root.geometry('700x600')
+    root.geometry('1000x950')
     root.resizable(False, False)
     root.iconbitmap('resources/icons/icon.ico')
     root.title('PySilon builder')


### PR DESCRIPTION
- Add compatibility for the `apk` package manager which is used on Alpine
- Change the way you choose your package manager. You now have to use numbers (1 = apt, 2 = dnf, etc.) instead of the first letter of the manager (names were overlapping (ex: ***a**pt* and ***a**pk*) and the old way might get confusing to some)

Tested in a VM on Alpine 3.18. You still need a Desktop Environment to run the builder.py though, which is not installed with the script, so it might cause errors if someone does not have a DE or WM.