### PR TITLE
fix ubuntu-based wine32 installation

### DIFF
--- a/PySilon-linux.sh
+++ b/PySilon-linux.sh
@@ -32,13 +32,18 @@ if [ "$mode" == 'c' ]; then
         read -p "$ " package_manager
 
         # Install wine using the selected package manager
-        if [ "$package_manager" == '1' ]; then
-            sudo apt update -y && sudo apt install wine -y
-        elif [ "$package_manager" == '2' ]; then
+        if [ "$package_manager" == '1' ]; then # Ubuntu
+            sudo dpkg --add-architecture i386
+            sudo mkdir -pm755 /etc/apt/keyrings
+            sudo wget -O /etc/apt/keyrings/winehq-archive.key https://dl.winehq.org/wine-builds/winehq.key
+            sudo apt update -y
+            sudo apt install --install-recommends winehq-stable -y
+            sudo apt install wine -y
+        elif [ "$package_manager" == '2' ]; then # Fedora
             sudo dnf update -y && sudo dnf install wine -y
-        elif [ "$package_manager" == '3' ]; then
+        elif [ "$package_manager" == '3' ]; then # Arch
             sudo pacman -Sy wine --noconfirm
-        elif [ "$package_manager" == '4' ]; then
+        elif [ "$package_manager" == '4' ]; then # Alpine
             echo -e "\e[1mNOTE: In case wine did not install, check '/etc/apk/repositories' and make sure to have community repos enabled, and restart the script.\e[0m"
             doas apk update && doas apk add wine
         elif [ -z "$package_manager" ]; then

--- a/PySilon-linux.sh
+++ b/PySilon-linux.sh
@@ -34,8 +34,6 @@ if [ "$mode" == 'c' ]; then
         # Install wine using the selected package manager
         if [ "$package_manager" == '1' ]; then # Ubuntu
             sudo dpkg --add-architecture i386
-            sudo mkdir -pm755 /etc/apt/keyrings
-            sudo wget -O /etc/apt/keyrings/winehq-archive.key https://dl.winehq.org/wine-builds/winehq.key
             sudo apt update -y
             sudo apt install --install-recommends winehq-stable -y
             sudo apt install wine -y


### PR DESCRIPTION
so we had an error when running builder.py on kali (it is ubuntu-based)
error message: https://discord.com/channels/1114568569850699847/1114689635138941028/1125067971593764975

seems like wine32 could not be installed on ubuntu by default, but only wine (x64)