### PR TITLE
Tilto66: Change directory to script location before setup to avoid bug during the setup process

### DIFF
--- a/PySilon.bat
+++ b/PySilon.bat
@@ -1,5 +1,6 @@
 @echo off
 title PySilon
+cd /d "%~dp0"
 echo Initializing the virtual environment...
 python -m venv pysilon
 cls


### PR DESCRIPTION
Change directory to script location before setup to avoid bug during the setup process with `PySilon.bat`